### PR TITLE
[WIP] fix test_analyzer_js

### DIFF
--- a/persper/graphs/git_tools.py
+++ b/persper/graphs/git_tools.py
@@ -1,23 +1,20 @@
 from git.exc import InvalidGitRepositoryError, NoSuchPathError
-from git import Repo
+import git
 import sys
-
-EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-
 
 def _diff_with_first_parent(commit):
     if len(commit.parents) == 0:
-        prev_commit = EMPTY_TREE_SHA
+        prev_commit = git.NULL_TREE
     else:
         prev_commit = commit.parents[0]
     # commit.diff automatically detect renames
     return commit.diff(prev_commit,
-                       create_patch=True, R=True, indent_heuristic=True)
+                       create_patch=True, indent_heuristic=True)
 
 
 def initialize_repo(repo_path):
     try:
-        repo = Repo(repo_path)
+        repo = git.Repo(repo_path)
     except InvalidGitRepositoryError as e:
         print("Invalid Git Repository!")
         sys.exit(-1)

--- a/test/test_graphs/test_analyzer_js.py
+++ b/test/test_graphs/test_analyzer_js.py
@@ -61,7 +61,7 @@ def test_az(az: Analyzer):
             'C': {'main.js:funcB:9:12': 1,
                   'main.js:global': 1,
                   'main.js:main:7:16': 1},
-            'B': {'main.js:funcB:9:11': 3,
+            'B': {'main.js:funcB:9:11': 1,
                   'main.js:global': 7,
                   'main.js:main:7:15': 7},
             'A': {'main.js:funcA:3:5': 3,


### PR DESCRIPTION
+ Instead of using a string **EMPTY_TREE_SHA**, we can use git.NULL_TREE as the init commit, which looks more coherent.
+ We diff the root commit by passing the __git.NULL_TREE__ to __commit.diff()__ since [v2.0.0](https://github.com/gitpython-developers/GitPython/blob/master/doc/source/changes.rst#200---features)
+ Pass the test/test_graphs/test_analyzer_js.py